### PR TITLE
Strengthen bank handling

### DIFF
--- a/examples/accel-gyro.toit
+++ b/examples/accel-gyro.toit
@@ -23,7 +23,7 @@ main:
   sensor.configure-accel
   sensor.configure-gyro
   50.repeat:
-    print "Acceleration: $sensor.read-accel"
-    print "Gyroscope: $sensor.read-gyro"
+    print " Acceleration: $sensor.read-accel"
+    print " Gyroscope:    $sensor.read-gyro"
     sleep --ms=1000
   sensor.off

--- a/examples/accel-gyro.toit
+++ b/examples/accel-gyro.toit
@@ -12,8 +12,8 @@ import icm20948
 
 main:
   bus := i2c.Bus
-    --sda=gpio.Pin 21
-    --scl=gpio.Pin 22
+    --sda=gpio.Pin 19
+    --scl=gpio.Pin 20
 
   device := bus.device icm20948.I2C-ADDRESS-ALT
 
@@ -22,7 +22,7 @@ main:
   sensor.on
   sensor.configure-accel
   sensor.configure-gyro
-  while true:
+  50.repeat:
     print "Acceleration: $sensor.read-accel"
     print "Gyroscope: $sensor.read-gyro"
     sleep --ms=1000

--- a/examples/accel-gyro.toit
+++ b/examples/accel-gyro.toit
@@ -1,6 +1,6 @@
-// Copyright (C) 2021 Toitware ApS. All rights reserved.
-// Use of this source code is governed by an MIT-style license that can be found
-// in the LICENSE file.
+// Copyright (C) 2026 Toit Contributors.
+// Use of this source code is governed by a Zero-Clause BSD license that can
+// be found in the EXAMPLES_LICENSE file.
 
 /**
 A simple example of how to use the ICM20948 driver.

--- a/examples/debug-ak09916.toit
+++ b/examples/debug-ak09916.toit
@@ -7,7 +7,7 @@ Uses I2C bypass mode to allow access to the AK09916 directly on the host
   I2C bus.  It requires the additional ak09916 driver package.
 
 This is for testing purposes only.  The bypass configuration will remain until
-  disabled, or until the next power on/reset.
+  either manually disabled again, or until the next power on/reset.
 */
 
 import gpio

--- a/examples/debug-ak09916.toit
+++ b/examples/debug-ak09916.toit
@@ -24,7 +24,7 @@ main:
       --frequency=400_000
 
   bus-device-count := bus.scan.size
-  if not bus.test icm20948.Driver.AK09916-I2C-ADDRESS:
+  if not bus.test icm20948.I2C-ADDRESS-ALT:
     print "ICM20948 not found."
     return
 
@@ -53,6 +53,6 @@ main:
   print "Magnetic Field: $ak-sensor.read-magnetic-field"
   print "Magnetic Bearing: $ak-sensor.read-bearing"
   print
-  100.repeat:
+  50.repeat:
     print " bearing $(%0.3f ak-sensor.read-bearing)"
     sleep --ms=100

--- a/examples/debug-ak09916.toit
+++ b/examples/debug-ak09916.toit
@@ -29,7 +29,7 @@ main:
     print "ICM20948 not found."
     return
 
-  print "Bus scan has $bus-device-count devices"
+  print " Bus scan has $bus-device-count devices"
   device := bus.device icm20948.I2C-ADDRESS-ALT
   sensor := icm20948.Driver device
   sensor.on
@@ -37,22 +37,21 @@ main:
   // Enable bypass:
   sensor.enable-i2c-bypass
   if not bus.test Ak0991x.I2C-ADDRESS:
-    print "bus missing the device. stopping..."
+    print " bus missing the device. stopping..."
     return
 
   new-bus-scan := bus.scan
-  print "After bypass, bus scan has $new-bus-scan.size devices"
+  print " After bypass, bus scan has $new-bus-scan.size devices"
 
   ak-device := bus.device Ak0991x.I2C-ADDRESS
   ak-sensor := Ak0991x ak-device
 
-  print "Bus contains AK09916."
-  print "Hardware ID: 0x$(%02x ak-sensor.get-hardware-id)"
+  print " Bus contains AK09916 hardware ID: 0x$(%02x ak-sensor.get-hardware-id)"
   ak-sensor.set-operating-mode Ak0991x.OPMODE-CONT-MODE1-10HZ
   sleep --ms=250
-  print "Data Ready: $ak-sensor.is-data-ready"
-  print "Magnetic Field: $ak-sensor.read-magnetic-field"
-  print "Magnetic Bearing: $ak-sensor.read-bearing"
+  print " Data Ready: $ak-sensor.is-data-ready"
+  print " Magnetic Field: $ak-sensor.read-magnetic-field"
+  print " Magnetic Bearing: $ak-sensor.read-bearing"
   print
   50.repeat:
     print " bearing $(%0.3f ak-sensor.read-bearing)"

--- a/examples/debug-ak09916.toit
+++ b/examples/debug-ak09916.toit
@@ -7,7 +7,8 @@ Uses I2C bypass mode to allow access to the AK09916 directly on the host
   I2C bus.  It requires the additional ak09916 driver package.
 
 This is for testing purposes only.  The bypass configuration will remain until
-  either manually disabled again, or until the next power on/reset.
+  either manually disabled (using `.disable-i2c-bypass`), or until the next
+  power on/reset.
 */
 
 import gpio

--- a/src/driver.toit
+++ b/src/driver.toit
@@ -223,19 +223,19 @@ class Driver:
 
   on:
     tries := 5
-    set-bank_ 0
-    while (reg_.read-u8 REGISTER-WHO-AM-I_) != WHO-AM-I_:
+    while (read-register_ 0 REGISTER-WHO-AM-I_) != WHO-AM-I_:
       tries--
       if tries == 0: throw "INVALID_CHIP"
       sleep --ms=1
 
     reset_
+    logger_.debug "device switched on"
 
     // Enable ACCEL and GYRO.
-    set-bank_ 0
     // print ((reg_.read_u8 REGISTER_PWR_MGMT_1_).stringify 16)
-    reg_.write-u8 REGISTER-PWR-MGMT-1_ 0b00000001
-    reg_.write-u8 REGISTER-PWR-MGMT-2_ 0b00000000
+    write-register_ 0 REGISTER-PWR-MGMT-1_ 0b00000001
+    write-register_ 0 REGISTER-PWR-MGMT-2_ 0b00000000
+
 
   configure-accel --scale/int=ACCEL-SCALE-2G:
     r := reg_.read-u8 REGISTER-LP-CONFIG_

--- a/src/driver.toit
+++ b/src/driver.toit
@@ -316,31 +316,34 @@ class Driver:
   Reads and optionally masks/parses register data. (Big-endian.)
   */
   read-register_ -> int
+      bank/int
       register/int
       --mask/int?=null
       --offset/int?=null
       --width/int=DEFAULT-REGISTER-WIDTH_
       --signed/bool=false:
-    assert: (width == 8) or (width == 16)
+    assert: 0 <= bank <= 3
+    assert: (width == WIDTH-8_) or (width == WIDTH-16_)
 
     if not mask: mask = (width == 8) ? 0xFF : 0xFFFF
     if not offset: offset = mask.count-trailing-zeros
 
-    // Check mask fits register width:
     assert:
-      if width == 8: (mask & ~0xff) == 0
+      if width == WIDTH-8_: (mask & ~0xff) == 0
       else: (mask & ~0xffff) == 0
     assert: mask != 0
 
-    full_width := (offset == 0) and ((width == 8 and mask == 0xFF) or (width == 16 and mask == 0xFFFF))
-    if signed and not full_width:
+    full-width := (offset == 0) and ((width == WIDTH-8_ and mask == 0xFF) or (width == WIDTH-16_ and mask == 0xFFFF))
+    if signed and not full-width:
       throw "masked signed read not supported (need sign-extension by field width)"
 
-    register-value/int := ?
-    if width == 8:
-      register-value = signed ? reg_.read-i8 register : reg_.read-u8 register
-    else:
-      register-value = signed ? reg_.read-i16-be register : reg_.read-u16-be register
+    register-value/int? := null
+    bank-mutex_.do:
+      set-bank-p_ bank
+      if width == WIDTH-8_:
+        register-value = signed ? reg_.read-i8 register : reg_.read-u8 register
+      else:
+        register-value = signed ? reg_.read-i16-be register : reg_.read-u16-be register
 
     if full-width:
       return register-value
@@ -351,24 +354,26 @@ class Driver:
   Writes register data - either masked or full register writes. (Big-endian.)
   */
   write-register_ -> none
+      bank/int
       register/int
       value/int
       --mask/int?=null
       --offset/int?=null
       --width/int=DEFAULT-REGISTER-WIDTH_
       --signed/bool=false:
-    assert: (width == 8) or (width == 16)
+    assert: 0 <= bank <= 3
+    assert: (width == WIDTH-8_) or (width == WIDTH-16_)
 
-    if not mask: mask = (width == 8) ? 0xFF : 0xFFFF
+    if not mask: mask = (width == WIDTH-8_) ? 0xff : 0xffff
     if not offset: offset = mask.count-trailing-zeros
 
     // Check mask fits register width:
     assert:
-      if width == 8: (mask & ~0xff) == 0
+      if width == WIDTH-8_: (mask & ~0xff) == 0
       else: (mask & ~0xffff) == 0
 
     // Determine if write is full width:
-    full-width := (offset == 0) and ((width == 8 and mask == 0xFF) or (width == 16 and mask == 0xFFFF))
+    full-width := (offset == 0) and ((width == WIDTH-8_ and mask == 0xff) or (width == WIDTH-16_ and mask == 0xffff))
 
     // For now don't accept negative numbers as masked writes.
     if signed and not full-width:
@@ -385,21 +390,24 @@ class Driver:
       if width == 8: assert: -128 <= value and value <= 127
       else: assert: -32768 <= value and value <= 32767
 
-    // Full-width direct write:
-    if full-width:
-      if width == 8:
-        signed ? reg_.write-i8 register value : reg_.write-u8 register value
+    bank-mutex_.do:
+      set-bank-p_ bank
+
+      // Full-width direct write:
+      if full-width:
+        if width == WIDTH-8_:
+          signed ? reg_.write-i8 register value : reg_.write-u8 register value
+        else:
+          signed ? reg_.write-i16-be register value : reg_.write-u16-be register value
+        return
+
+      // Read Reg for modification:
+      old-value/int := (width == WIDTH-8_) ? reg_.read-u8 register : reg_.read-u16-be register
+      reg-mask/int := (width == WIDTH-8_) ? 0xFF : 0xFFFF
+      new-value/int := (old-value & ~mask) | ((value & field-mask) << offset) & reg-mask
+
+      // Write modified value:
+      if width == WIDTH-8_:
+        reg_.write-u8 register new-value
       else:
-        signed ? reg_.write-i16-be register value : reg_.write-u16-be register value
-      return
-
-    // Read Reg for modification:
-    old-value/int := (width == 8) ? reg_.read-u8 register : reg_.read-u16-be register
-    reg-mask/int := (width == 8) ? 0xFF : 0xFFFF
-    new-value/int := (old-value & ~mask) | ((value & field-mask) << offset) & reg-mask
-
-    // Write modified value:
-    if width == 8:
-      reg_.write-u8 register new-value
-    else:
-      reg_.write-u16-be register new-value
+        reg_.write-u16-be register new-value

--- a/src/driver.toit
+++ b/src/driver.toit
@@ -238,36 +238,28 @@ class Driver:
 
 
   configure-accel --scale/int=ACCEL-SCALE-2G:
-    r := reg_.read-u8 REGISTER-LP-CONFIG_
-    reg_.write-u8 REGISTER-LP-CONFIG_ r & ~0b100000
+    set-accel-duty-cycle-mode_ true
 
     // Configure accel.
     cfg := 0b00111_00_1
     cfg |= scale << 1
-    set-bank_ 2
-    reg_.write-u8 REGISTER-ACCEL-CONFIG_ cfg
-    set-bank_ 0
+    write-register_ 2 REGISTER-ACCEL-CONFIG_ cfg
 
     accel-sensitivity_ = ACCEL-SENSITIVITY_[scale]
-
     sleep --ms=10
+    logger_.debug "accelerometer configured"
 
   configure-gyro --scale/int=GYRO-SCALE-250DPS:
-    r := reg_.read-u8 REGISTER-LP-CONFIG_
-    reg_.write-u8 REGISTER-LP-CONFIG_ r & ~0b10000
+    set-gyro-duty-cycle-mode_ true
 
-    set-bank_ 2
-
-    //reg_.write_u8 REGISTER_GYRO_SMPLRT_DIV_ 0
-
-    reg_.write-u8 REGISTER-GYRO-CONFIG-1_ 0b111_00_1 | scale << 1
-    //reg_.write_u8 REGISTER_GYRO_CONFIG_2_ 0b1111
-
-    set-bank_ 0
+    //write-register_ 2 REGISTER_GYRO_SMPLRT_DIV_ 0
+    write-register_ 2 REGISTER-GYRO-CONFIG-1_ (0b111_00_1 | scale << 1)
+    //write-register_ 2 REGISTER_GYRO_CONFIG_2_ 0b1111
 
     gyro-sensitivity_ = GYRO-SENSITIVITY_[scale]
-
     sleep --ms=10
+    logger_.debug "gyroscope configured"
+
 
   off:
 

--- a/src/driver.toit
+++ b/src/driver.toit
@@ -118,8 +118,8 @@ class Driver:
   //   (writes or reads).  Result goes into $REGISTER-I2C-SLV4-DI_.
   //   Must wait for 'DONE' from $REGISTER-I2C-MST-STATUS_.
   static REGISTER-I2C-SLV0-ADDR_      ::= 0x03  // R/W [7] and PHY address [0..6] of I2C Slave x.
-  static REGISTER-I2C-SLV0-REG_       ::= 0x04  // I2C slave x register address from where to begin data transfer.
-  static REGISTER-I2C-SLV0-CTRL_      ::= 0x05  // Bitmask of properties for the read.
+  static REGISTER-I2C-SLV0-REG_       ::= 0x04  // I2C slave x register address from where to begin shadowing data to ICM20948.
+  static REGISTER-I2C-SLV0-CTRL_      ::= 0x05  // Bitmask of properties for the read, including data length to retreive.
   static REGISTER-I2C-SLV0-DO_        ::= 0x06  // Data out when slave x is set to write.
 
   static REGISTER-I2C-SLV1-ADDR_      ::= 0x07

--- a/src/driver.toit
+++ b/src/driver.toit
@@ -9,6 +9,8 @@ import math
 import log
 import monitor
 
+/** Toit driver for the ICM20948 9-axis motion sensing IC. */
+
 I2C-ADDRESS     ::= 0b1101000
 I2C-ADDRESS-ALT ::= 0b1101001
 
@@ -222,7 +224,7 @@ class Driver:
     reg_ = dev.registers
     logger_ = logger.with-name "icm20948"
 
-    // Set current bank in sync with local var
+    // Set current bank in sync with local variable.
     set-bank-p_ 0
 
   on:
@@ -317,7 +319,7 @@ class Driver:
   /**
   Sets the current bank for register reads and writes.
 
-  Tracks current bank in $bank_ to compare and only send the bank set command
+  Tracks current bank to compare and only send the bank set command
     when necessary.  Significantly reduces traffic on the I2C bus.
   */
   set-bank-p_ bank/int:

--- a/src/driver.toit
+++ b/src/driver.toit
@@ -58,9 +58,9 @@ class Driver:
   static REGISTER-GYRO-ZOUT-H_    ::= 0x37
   static REGISTER-GYRO-ZOUT-L_    ::= 0x38
 
-  static REGISTER-EXT-SLV-DATA-00_ ::= 0x3b
-  static REGISTER-EXT-SLV-DATA-01_ ::= 0x3c
-  static REGISTER-EXT-SLV-DATA-02_ ::= 0x3d
+  static REGISTER-EXT-SLV-DATA-00_ ::= 0x3B
+  static REGISTER-EXT-SLV-DATA-01_ ::= 0x3C
+  static REGISTER-EXT-SLV-DATA-02_ ::= 0x3D
   static REGISTER-EXT-SLV-DATA-23_ ::= 0x52
 
   static REGISTER-FIFO-EN-1_       ::= 0x66
@@ -371,8 +371,8 @@ class Driver:
     if not offset: offset = mask.count-trailing-zeros
 
     assert:
-      if width == WIDTH-8_: (mask & ~0xff) == 0
-      else: (mask & ~0xffff) == 0
+      if width == WIDTH-8_: (mask & ~0xFF) == 0
+      else: (mask & ~0xFFFF) == 0
     assert: mask != 0
 
     full-width := (offset == 0) and ((width == WIDTH-8_ and mask == 0xFF) or (width == WIDTH-16_ and mask == 0xFFFF))
@@ -406,16 +406,16 @@ class Driver:
     assert: 0 <= bank <= 3
     assert: (width == WIDTH-8_) or (width == WIDTH-16_)
 
-    if not mask: mask = (width == WIDTH-8_) ? 0xff : 0xffff
+    if not mask: mask = (width == WIDTH-8_) ? 0xFF : 0xFFFF
     if not offset: offset = mask.count-trailing-zeros
 
     // Check mask fits register width:
     assert:
-      if width == WIDTH-8_: (mask & ~0xff) == 0
-      else: (mask & ~0xffff) == 0
+      if width == WIDTH-8_: (mask & ~0xFF) == 0
+      else: (mask & ~0xFFFF) == 0
 
     // Determine if write is full width:
-    full-width := (offset == 0) and ((width == WIDTH-8_ and mask == 0xff) or (width == WIDTH-16_ and mask == 0xffff))
+    full-width := (offset == 0) and ((width == WIDTH-8_ and mask == 0xFF) or (width == WIDTH-16_ and mask == 0xFFFF))
 
     // For now don't accept negative numbers as masked writes.
     if signed and not full-width:

--- a/src/driver.toit
+++ b/src/driver.toit
@@ -260,7 +260,6 @@ class Driver:
     sleep --ms=10
     logger_.debug "gyroscope configured"
 
-
   off:
 
   read-point_ reg/int sensitivity/float -> math.Point3f:

--- a/src/driver.toit
+++ b/src/driver.toit
@@ -205,6 +205,7 @@ class Driver:
   reg_/Registers := ?
   logger_/log.Logger := ?
   bank-mutex_ := monitor.Mutex
+  bank_/int := ?
 
   constructor dev/Device --logger/log.Logger=log.default:
     reg_ = dev.registers
@@ -298,8 +299,20 @@ class Driver:
         throw "Bus did not recover from reset after 100ms"
     write-register_ 0 REGISTER-PWR-MGMT-1_ 1 --mask=PWR-MGMT-1-CLKSEL_
 
+  /**
+  Sets the current bank for register reads and writes.
+
+  Tracks current bank in $bank_ and sets only when necessary, in order to
+    reduce traffic on the I2C bus.
+  */
   set-bank-p_ bank/int:
+    assert: 0 <= bank <= 3
+    if bank_ == bank:
+      //logger_.debug "bank already set" --tags={"bank":bank}
+      return
     reg_.write-u8 REGISTER-REG-BANK-SEL_ bank << 4
+    //logger_.debug "set bank" --tags={"bank":bank}
+    bank_ = bank
 
 
   /**

--- a/src/driver.toit
+++ b/src/driver.toit
@@ -287,12 +287,18 @@ class Driver:
     return read-point_ REGISTER-GYRO-XOUT-H_ gyro-sensitivity_
 
   reset_:
-    set-bank_ 0
-    reg_.write-u8 REGISTER-PWR-MGMT-1_ 0b10000001
-    sleep --ms=5
-    set-bank_ 0
+    bank-mutex_.do:
+      set-bank-p_ 0
+      reg_.write-u8 REGISTER-PWR-MGMT-1_ PWR-MGMT-1-DEVICE-RESET_
+      bank_ = -1
+      sleep --ms=100
+      set-bank-p_ 0
+      if (reg_.read-u8 REGISTER-WHO-AM-I_) != WHO-AM-I_:
+        logger_.error "bus did not recover from reset after 100ms"
+        throw "Bus did not recover from reset after 100ms"
+    write-register_ 0 REGISTER-PWR-MGMT-1_ 1 --mask=PWR-MGMT-1-CLKSEL_
 
-  set-bank_ bank/int:
+  set-bank-p_ bank/int:
     reg_.write-u8 REGISTER-REG-BANK-SEL_ bank << 4
 
 

--- a/src/driver.toit
+++ b/src/driver.toit
@@ -356,8 +356,10 @@ class Driver:
     // Enable bypass mux:
     write-register_ 0 REGISTER-INT-PIN-CFG_ 1 --mask=INT-PIN-CFG-BYPASS-EN_
 
-
-
+  /** Reverses $enable-i2c-bypass. */
+  disable-i2c-bypass -> none:
+    write-register_ 0 REGISTER-INT-PIN-CFG_ 0 --mask=INT-PIN-CFG-BYPASS-EN_
+    write-register_ 0 REGISTER-USER-CTRL_ 1 --mask=USER-CTRL-I2C-MST-EN_
 
   /**
   Reads and optionally masks/parses register data. (Big-endian.)

--- a/src/driver.toit
+++ b/src/driver.toit
@@ -1,4 +1,6 @@
-// Copyright (C) 2021 Toitware ApS. All rights reserved.
+// Copyright (C) 2026 Toit Contributors. All rights reserved.
+// Use of this source code is governed by a MIT-style license that can be found
+// in the LICENSE file.
 
 import io
 import serial.device show Device

--- a/src/driver.toit
+++ b/src/driver.toit
@@ -314,6 +314,18 @@ class Driver:
     reg_.write-u8 REGISTER-REG-BANK-SEL_ bank << 4
     bank_ = bank
 
+  /** Sets duty-cycle mode for accelerometer. */
+  set-accel-duty-cycle-mode_ on/bool -> none:
+    value := 0
+    if on: value = 1
+    write-register_ 0 REGISTER-LP-CONFIG_ value --mask=LP-CONFIG-I2C-ACCEL-CYCLE_
+
+  /** Sets duty-cycle mode for gyroscope. */
+  set-gyro-duty-cycle-mode_ on/bool -> none:
+    value := 0
+    if on: value = 1
+    write-register_ 0 REGISTER-LP-CONFIG_ value --mask=LP-CONFIG-I2C-GYRO-CYCLE_
+
   /**
   Enables I2C bypass such that AK09916 appears and is reachable on external I2C bus.
 

--- a/src/driver.toit
+++ b/src/driver.toit
@@ -5,6 +5,7 @@ import serial.device show Device
 import serial.registers show Registers
 import math
 import log
+import monitor
 
 I2C-ADDRESS     ::= 0b1101000
 I2C-ADDRESS-ALT ::= 0b1101001
@@ -203,6 +204,7 @@ class Driver:
 
   reg_/Registers := ?
   logger_/log.Logger := ?
+  bank-mutex_ := monitor.Mutex
 
   constructor dev/Device --logger/log.Logger=log.default:
     reg_ = dev.registers

--- a/src/driver.toit
+++ b/src/driver.toit
@@ -205,11 +205,14 @@ class Driver:
   reg_/Registers := ?
   logger_/log.Logger := ?
   bank-mutex_ := monitor.Mutex
-  bank_/int := ?
+  bank_/int := -1
 
   constructor dev/Device --logger/log.Logger=log.default:
     reg_ = dev.registers
     logger_ = logger.with-name "icm20948"
+
+    // Set current bank in sync with local var
+    set-bank-p_ 0
 
   on:
     tries := 5

--- a/src/driver.toit
+++ b/src/driver.toit
@@ -356,6 +356,9 @@ class Driver:
     // Enable bypass mux:
     write-register_ 0 REGISTER-INT-PIN-CFG_ 1 --mask=INT-PIN-CFG-BYPASS-EN_
 
+
+
+
   /**
   Reads and optionally masks/parses register data. (Big-endian.)
   */


### PR DESCRIPTION
To introduce FIFO we need to ensure that a register read/write can complete without the risk of another task/process changing the current bank halfway through a read/write.  

This change:
- Introduces a mutex.
- Changes `read-register_` and `write-register_` to use it, and require callers to specify the bank number parameter.
- Force all other functions to use these two. (Where other direct reads/writes are absolutely required, implement the mutex.)
- Changes (potentially) infinite waits on `read-accel`/`read-gyro` to use `with-timeout`.

Change might look big like a big diff.. these are just safer fundamentals needed for later!